### PR TITLE
use escaped double quotes for format script

### DIFF
--- a/_posts/2017-03-30-prettier.md
+++ b/_posts/2017-03-30-prettier.md
@@ -75,7 +75,7 @@ First, adding the following scripts in the `package.json` file enables us to use
 
 {% highlight javascript %}
     "format": "prettier-eslint --write",
-    "format-sources": "prettier-eslint --write 'src/!(vendor)/**/*.{js,jsx}' 'tests/**/*.js' '{config/gulp,config/ci,scripts,ci}/**/*.js' '*.js' 'playground/**/*.{js,jsx}'",
+    "format-sources": "prettier-eslint --write \"src/!(vendor)/**/*.{js,jsx}\" \"tests/**/*.js\" \"{config/gulp,config/ci,scripts,ci}/**/*.js\" \"*.js\" \"playground/**/*.{js,jsx}\"",
 {% endhighlight %}
 
 The first line is used to format files provided as parameters and is used in a git pre-commit hook. The second line was there to format the whole codebase and should not be used anymore. This command takes around 1 minute to execute which is a little too long to be used in the development process. It’s more interesting to plug Prettier in our IDE and only format modified files.    


### PR DESCRIPTION
Because Windows doesn't do well with single quotes