### PR TITLE
Remove eslint link in prettier article

### DIFF
--- a/_posts/2017-03-30-prettier.md
+++ b/_posts/2017-03-30-prettier.md
@@ -39,7 +39,7 @@ For a relatively big project like ours, we prefer adding some consistency to our
 
 ## How to configure it?
 
-We already have [eslint setup](https://github.m6web.fr/m6web/eslint-config-m6web) in our project with some rule tweaks. So for us, Prettier had to interface smoothly with eslint. Fortunately it comes with a bunch of useful plugins.
+We already have eslint setup in our project with some rule tweaks. So for us, Prettier had to interface smoothly with eslint. Fortunately it comes with a bunch of useful plugins.
 
 - [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier): this library disables all eslint rules that conflict with the Prettier formatting. Without it we would need to turn off those rules manually.
 - [eslint-plugin-prettier](https://github.com/not-an-aardvark/eslint-plugin-prettier): this library includes Prettier proper formatting as an eslint rule. So if our code is not well formatted, eslint will throw errors. This is the most important plugin for us, as it makes the linting fail if the code is not well formatted. Formatting is now mandatory!


### PR DESCRIPTION
M6Web eslint config is not public, so it could not be linked in the article

close #169