### PR TITLE
Delete surge from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,4 @@ language: ruby
 rvm:
   2.2
 
-before_install:
-- npm install -g surge
-- |
-  curl https://api.github.com/repos/m6web/m6web.github.io/statuses/$TRAVIS_COMMIT?access_token=$GITHUB_TOKEN -H "Content-Type: application/json" -X POST -d "{\"state\": \"pending\", \"description\": \"Preview\", \"target_url\": \"http://techm6web.surge.sh\"}"
-
 script: "bundle exec jekyll build"
-
-after_success:
-  - surge --project _site/ --domain techm6webfr.surge.sh
-  - |
-    curl https://api.github.com/repos/m6web/m6web.github.io/statuses/$TRAVIS_COMMIT?access_token=$GITHUB_TOKEN -H "Content-Type: application/json" -X POST -d "{\"state\": \"success\", \"description\": \"Preview\", \"target_url\": \"http://techm6web.surge.sh\"}"


### PR DESCRIPTION
Surge servait à faire une preview du blog avant publication, mais l'intégration n'a jamais très bien marché. Je préfère supprimer ceci (qui en plus casse régulièrement l'inté continue) en attendant de remettre en place quelque chose de mieux.