### PR TITLE
Fixing highlighting errors (pygments to rouge)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,7 +53,7 @@ links:
 # http://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 timezone:    Europe/Paris
 future:      true
-pygments:    true
+highlighter: rouge
 markdown:    kramdown
 
 # https://github.com/mojombo/jekyll/wiki/Permalinks


### PR DESCRIPTION
## Why?
After merging my previous PR, GitHub Pages sent me an email:

> The page build completed successfully, but returned the following warning for the `master` branch:
 You are attempting to use the 'pygments' highlighter, which is currently unsupported on GitHub Pages. Your site will use 'rouge' for highlighting instead. To suppress this warning, change the 'highlighter' value to 'rouge' in your '_config.yml' and ensure the 'pygments' key is unset. For more information, see https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors.

> For information on troubleshooting Jekyll see:
  https://help.github.com/articles/troubleshooting-jekyll-builds

## How?
https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors

## Note
![](https://i.imgur.com/uH8QQ.gif)