### PR TITLE
chore(ci): prefer github action instead of travis-ci

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,19 @@
+name: Continous Integration
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.2'
+      - run: gem install bundler
+      - run: bundle install --jobs 4 --retry 3
+      - run: bundle exec jekyll build

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.2'
+          ruby-version: '2.6'
       - run: gem install bundler
       - run: bundle install --jobs 4 --retry 3
       - run: bundle exec jekyll build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: ruby
-
-rvm:
-  2.2
-
-script: "bundle exec jekyll build"


### PR DESCRIPTION
## Why

Travis-ci free tier is very slow now and with a lot of queuing. Github Action is a great and simple alternative.

## How

- add simple CI workflow
- remove travis workflow